### PR TITLE
Fix GWN image links

### DIFF
--- a/GWN.html
+++ b/GWN.html
@@ -15,7 +15,7 @@
 <body>
   <link href="https://fonts.googleapis.com/css?family=Comfortaa:400,700" rel="stylesheet">
   <link type="text/css" href="/main.css" rel="stylesheet">
-  <img src="https://raw.githubusercontent.com/SimpleBinary/GWN/master/Media/GWN.png" width="100%" height="width">
+  <img src="https://raw.githubusercontent.com/SimpleBinary/GWN/master/media/GWN.png" width="100%" height="width">
   <h2>Greg Would Not</h2>
   <h4>An interpreted programming language designed to be easy to learn, with implementations in Python and Go, Written by Dandigit and SimpleBinary</h4>
   <h4>Coming to You in 2019</h4>


### PR DESCRIPTION
The capital 'M' of the 'Media' folder on the GWN repository was really annoying me, so I changed it to 'media' and it looks like I broke half of the internet.